### PR TITLE
Lowercase name should be used for resource group in azd init input

### DIFF
--- a/samples/Quickstart/README.md
+++ b/samples/Quickstart/README.md
@@ -48,6 +48,7 @@ This quickstart will create the below resources. These will be used both for loc
     ```dotnetcli
     azd init --template Azure-Samples/azure-health-data-services-toolkit-fhir-function-quickstart
     ```
+    > **Note:** lower-case name is needed to be compatible with all the resource types
 
 3. If you want to use an existing FHIR Service, you need to open `infra/main.parameters.json` in a code editor and change the following settings:
 


### PR DESCRIPTION
## Description
Note to use lower-case names for the cross-resource naming compatibility when using `azd init`

## Related issues
Addresses [issue #].

## Testing
Describe how this change was tested.

## Reviewer Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] Tag the PR with the type of update: **Bug**, **New-Sample**, **Enhancement**, or **New-Feature**
- [x] CI is green before merge
